### PR TITLE
Feature/better map rendering

### DIFF
--- a/editor/src/cpp/Editor.cpp
+++ b/editor/src/cpp/Editor.cpp
@@ -142,7 +142,7 @@ void Editor::linkSelection()
       {
          static_cast<void>(topic.newRole(association));
 
-         for (Occurrence const &occurrence : topic.occurrencesIn(viewScope))
+         for (Occurrence const &occurrence : topic.findOccurrences(occurrenceIds))
          {
             auto occurrenceLocation = occurrence.getLocation().getSpacial().getAbsoluteReference();
             x += occurrenceLocation.X();

--- a/editor/test/EditorTest.cpp
+++ b/editor/test/EditorTest.cpp
@@ -491,15 +491,16 @@ TEST_P(EditorTest, newAssociationsCreatedByLinkingThroughSelectionIsCentredBetwe
    then().view().ofMap().shouldHaveOneAssociationNear(SpacialCoordinate::absoluteAt(-2.5f, 15.0f));
 }
 
-TEST_P(EditorTest, newAssociationsCreatedByLinkingThroughSelectionIsCentredBetweenAllOccurrences)
+TEST_P(EditorTest, newAssociationsCreatedByLinkingThroughSelectionIsCentredBetweenAllSelectedOccurrences)
 {
    Identifier topicId1 = given().user().requestsANewTopic().at(SpacialCoordinate::absoluteAt(-5.0f, 10.0f));
    Identifier topicId2 = given().user().requestsANewTopic().at(SpacialCoordinate::absoluteAt(0.0f, 20.0f));
+   auto const &firstTopic1Occurrence = occurrenceOf(topicId1);
    given().user().requestsANewOccurrence(topicId1).at(SpacialCoordinate::absoluteAt(-10.0f, 3.0f));
-   given().user().selects(SelectedType::Occurrence, occurrenceOf(topicId1).getId());
+   given().user().selects(SelectedType::Occurrence, firstTopic1Occurrence.getId());
    given().user().togglesSelectionOf(SelectedType::Occurrence, occurrenceOf(topicId2).getId());
    when().user().linksTheSelection();
-   then().view().ofMap().shouldHaveOneAssociationNear(SpacialCoordinate::absoluteAt(-5.0f, 11.0f));
+   then().view().ofMap().shouldHaveOneAssociationNear(SpacialCoordinate::absoluteAt(-2.5f, 15.0f));
 }
 
 TEST_P(EditorTest, newTopicHasItsOccurrenceSelected)

--- a/frontend/src/cpp/DirectMapRenderer.cpp
+++ b/frontend/src/cpp/DirectMapRenderer.cpp
@@ -138,21 +138,21 @@ void DirectMapRenderer::renderRoleLine(Identifier, Vector2 a, Vector2 b, Style c
    if ((length > 0.0001f) && reified)
    {
       auto drawWithOffset = [length, a, b, lineThickness, color](float offset) {
-         Vector2 shiftedProjected {
+         Vector2 shiftedA {
             .x = a.x + offset * (b.y - a.y) / length,
             .y = a.y + offset * (a.x - b.x) / length,
          };
-         Vector2 shiftedAssociation {
+         Vector2 shiftedB {
             .x = b.x + offset * (b.y - a.y) / length,
             .y = b.y + offset * (a.x - b.x) / length,
          };
-         float diffX = shiftedAssociation.x - shiftedProjected.x;
-         float diffY = shiftedAssociation.y - shiftedProjected.y;
-         shiftedProjected.x += diffX / 3;
-         shiftedProjected.y += diffY / 3;
-         shiftedAssociation.x += -diffX / 3;
-         shiftedAssociation.y += -diffY / 3;
-         DrawLineEx(shiftedProjected, shiftedAssociation, lineThickness, color);
+         float diffX = shiftedB.x - shiftedA.x;
+         float diffY = shiftedB.y - shiftedA.y;
+         shiftedA.x += diffX / 3;
+         shiftedA.y += diffY / 3;
+         shiftedB.x += -diffX / 3;
+         shiftedB.y += -diffY / 3;
+         DrawLineEx(shiftedA, shiftedB, lineThickness, color);
       };
 
       drawWithOffset(+3.0f);

--- a/frontend/src/cpp/FocusInterceptor.cpp
+++ b/frontend/src/cpp/FocusInterceptor.cpp
@@ -5,12 +5,14 @@
 #pragma GCC diagnostic pop
 
 #include "contomap/frontend/FocusInterceptor.h"
+#include "contomap/frontend/Geometry.h"
 
 using contomap::frontend::AssociationFocusItem;
 using contomap::frontend::Focus;
 using contomap::frontend::FocusInterceptor;
 using contomap::frontend::OccurrenceFocusItem;
 using contomap::frontend::RoleFocusItem;
+using contomap::frontend::geometry::centerOf;
 using contomap::model::Identifier;
 using contomap::model::Style;
 
@@ -55,9 +57,4 @@ void FocusInterceptor::renderRoleLine(Identifier id, Vector2 a, Vector2 b, Style
       newFocus.registerItem(std::make_shared<RoleFocusItem>(id), 0.0f);
    }
    next.renderRoleLine(id, a, b, style, lineThickness, reified);
-}
-
-Vector2 FocusInterceptor::centerOf(Rectangle area)
-{
-   return Vector2 { .x = area.x + (area.width / 2.0f), .y = area.y + (area.height / 2.0f) };
 }

--- a/frontend/src/cpp/Geometry.cpp
+++ b/frontend/src/cpp/Geometry.cpp
@@ -1,0 +1,51 @@
+#include <algorithm>
+#include <array>
+
+#include <raylib.h>
+
+#include "contomap/frontend/Geometry.h"
+
+std::optional<Vector2> contomap::frontend::geometry::intersectLines(std::tuple<Vector2, Vector2> a, std::tuple<Vector2, Vector2> b)
+{
+   auto [a1, a2] = a;
+   auto [b1, b2] = b;
+   float diff = (b2.y - b1.y) * (a2.x - a1.x) - (b2.x - b1.x) * (a2.y - a1.y);
+   if (std::abs(diff) < 0.000001f) [[unlikely]]
+   {
+      return {};
+   }
+   float uA = ((b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)) / diff;
+   float uB = ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / diff;
+
+   if ((uA >= 0.0f) && (uA <= 1.0f) && (uB >= 0.0f) && (uB <= 1.0f))
+   {
+      return { Vector2 { .x = a1.x + (uA * (a2.x - a1.x)), .y = a1.y + (uA * (a2.y - a1.y)) } };
+   }
+   return {};
+}
+
+std::optional<Vector2> contomap::frontend::geometry::intersectLineIntoBoxCenter(Vector2 start, Rectangle box)
+{
+   auto line = std::make_tuple(start, contomap::frontend::geometry::centerOf(box));
+   Vector2 bl { .x = box.x, .y = box.y };
+   Vector2 tl { .x = box.x, .y = box.y + box.height };
+   Vector2 tr { .x = box.x + box.width, .y = box.y + box.height };
+   Vector2 br { .x = box.x + box.width, .y = box.y };
+   std::array<std::optional<Vector2>, 4> matches {
+      intersectLines(line, std::make_tuple(bl, tl)),
+      intersectLines(line, std::make_tuple(tl, tr)),
+      intersectLines(line, std::make_tuple(tr, br)),
+      intersectLines(line, std::make_tuple(br, bl)),
+   };
+   auto found = std::find_if(matches.begin(), matches.end(), [](auto const &entry) { return entry.has_value(); });
+   if (found != matches.end()) [[likely]]
+   {
+      return *found;
+   }
+   return {};
+}
+
+Vector2 contomap::frontend::geometry::centerOf(Rectangle area)
+{
+   return Vector2 { .x = area.x + (area.width / 2.0f), .y = area.y + (area.height / 2.0f) };
+}

--- a/frontend/src/cpp/MainWindow.cpp
+++ b/frontend/src/cpp/MainWindow.cpp
@@ -15,6 +15,7 @@
 #include "contomap/frontend/Colors.h"
 #include "contomap/frontend/DirectMapRenderer.h"
 #include "contomap/frontend/FocusInterceptor.h"
+#include "contomap/frontend/Geometry.h"
 #include "contomap/frontend/HelpDialog.h"
 #include "contomap/frontend/LoadDialog.h"
 #include "contomap/frontend/LocateTopicAndActDialog.h"
@@ -45,6 +46,8 @@ using contomap::frontend::MapRenderer;
 using contomap::frontend::Names;
 using contomap::frontend::RenameTopicDialog;
 using contomap::frontend::RenderContext;
+using contomap::frontend::geometry::centerOf;
+using contomap::frontend::geometry::intersectLineIntoBoxCenter;
 using contomap::model::Association;
 using contomap::model::Associations;
 using contomap::model::Identifier;
@@ -330,8 +333,11 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
    auto const &viewScope = view.ofViewScope();
    auto const &map = view.ofMap();
 
+   Font font = GetFontDefault();
+   float spacing = 1.0f;
+
    Identifiers associationIds;
-   std::map<Identifier, Vector2> associationLocationsById;
+   std::map<Identifier, Rectangle> associationAreasById;
    auto drawOffsetIf = [&selectionOffset](bool isSelected) { return isSelected ? selectionOffset : SpacialCoordinate::Offset::of(0.0f, 0.0f); };
 
    auto visibleAssociations = map.find(Associations::thatAreIn(viewScope));
@@ -349,9 +355,7 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
       auto spacialLocation = visibleAssociation.getLocation().getSpacial().getAbsoluteReference().plus(drawOffsetIf(associationIsSelected));
       Vector2 projectedLocation { .x = spacialLocation.X(), .y = spacialLocation.Y() };
 
-      Font font = GetFontDefault();
       float fontSize = 16.0f;
-      float spacing = 1.0f;
       auto textSize = MeasureTextEx(font, nameText.c_str(), fontSize, spacing);
       float lineThickness = 2.0f;
 
@@ -380,7 +384,7 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
       };
 
       associationIds.add(visibleAssociation.getId());
-      associationLocationsById[visibleAssociation.getId()] = projectedLocation;
+      associationAreasById[visibleAssociation.getId()] = area;
 
       auto associationStyle
          = Styles::resolve(visibleAssociation.getAppearance(), visibleAssociation.getType(), view.ofViewScope(), view.ofMap()).withDefaultsFrom(defaultStyle);
@@ -413,6 +417,33 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
          auto spacialLocation = occurrence.getLocation().getSpacial().getAbsoluteReference().plus(drawOffsetIf(occurrenceIsSelected));
          Vector2 projectedLocation { .x = spacialLocation.X(), .y = spacialLocation.Y() };
 
+         float occurrenceFontSize = 16.0f;
+         auto occurrenceTextSize = MeasureTextEx(font, nameText.c_str(), occurrenceFontSize, spacing);
+
+         float occurrenceBorderThickness = 2.0f;
+
+         Rectangle occurrenceTextArea {
+            .x = projectedLocation.x - occurrenceTextSize.x / 2.0f,
+            .y = projectedLocation.y - occurrenceTextSize.y / 2.0f,
+            .width = occurrenceTextSize.x,
+            .height = occurrenceTextSize.y,
+         };
+         float occurrencePlatePadding = 2.0f;
+         Rectangle occurrencePlate {
+            .x = occurrenceTextArea.x - occurrencePlatePadding,
+            .y = occurrenceTextArea.y - occurrencePlatePadding,
+            .width = occurrenceTextArea.width + occurrencePlatePadding * 2.0f,
+            .height = occurrenceTextArea.height + occurrencePlatePadding * 2.0f,
+         };
+         float occurrenceReifierPadding = 2.0f;
+         float occurrenceReifierOffset = occurrenceBorderThickness + occurrenceReifierPadding;
+         Rectangle occurrenceArea {
+            .x = occurrencePlate.x - occurrenceReifierOffset - occurrenceBorderThickness,
+            .y = occurrencePlate.y - occurrenceBorderThickness,
+            .width = occurrencePlate.width + (occurrenceReifierOffset * 2.0f) + (occurrenceBorderThickness * 2.0f),
+            .height = occurrencePlate.height + (occurrenceBorderThickness * 2.0f),
+         };
+
          for (Role const &role : roles)
          {
             bool roleIsSelected = selection.contains(SelectedType::Role, role.getId());
@@ -426,68 +457,52 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
 
             auto roleStyle = Styles::resolve(role.getAppearance(), role.getType(), view.ofViewScope(), view.ofMap()).withDefaultsFrom(defaultStyle);
 
-            float thickness = 1.0f;
+            float roleLineThickness = 1.0f;
             if (roleIsSelected)
             {
                roleStyle = selectedStyle(roleStyle);
-               thickness += 2.0f;
+               roleLineThickness += 2.0f;
             }
             if (focus.isRole(role.getId()))
             {
                roleStyle = highlightedStyle(roleStyle);
-               thickness += 0.5f;
+               roleLineThickness += 0.5f;
             }
 
-            auto associationLocation = associationLocationsById[role.getParent()];
-            renderer.renderRoleLine(role.getId(), projectedLocation, associationLocation, roleStyle, thickness, role.hasReifier());
+            auto associationArea = associationAreasById[role.getParent()];
+            auto rolePointApproxOccurrence = intersectLineIntoBoxCenter(centerOf(associationArea), occurrenceArea);
+            auto rolePointApproxAssociation = intersectLineIntoBoxCenter(centerOf(occurrenceArea), associationArea);
+            if (!rolePointApproxOccurrence.has_value() || !rolePointApproxAssociation.has_value()) [[unlikely]]
+            {
+               // can happen if either has its center within the area of the other
+               continue;
+            }
+            auto rolePointOccurrence = intersectLineIntoBoxCenter(rolePointApproxAssociation.value(), occurrenceArea);
+            auto rolePointAssociation = intersectLineIntoBoxCenter(rolePointApproxOccurrence.value(), associationArea);
+            if (!rolePointOccurrence.has_value() || !rolePointAssociation.has_value()) [[unlikely]]
+            {
+               // can happen if the point on the area border is within the area of the other
+               continue;
+            }
+
+            renderer.renderRoleLine(role.getId(), rolePointOccurrence.value(), rolePointAssociation.value(), roleStyle, roleLineThickness, role.hasReifier());
 
             if (!roleTitle.empty())
             {
-               Font font = GetFontDefault();
-               float fontSize = 10.0f;
-               float spacing = 1.0f;
-               auto textSize = MeasureTextEx(font, roleTitle.c_str(), fontSize, spacing);
-               float plateHeight = textSize.y;
+               float roleFontSize = 10.0f;
+               auto roleTextSize = MeasureTextEx(font, roleTitle.c_str(), roleFontSize, spacing);
+               float plateHeight = roleTextSize.y;
 
-               Rectangle area {
-                  .x = (projectedLocation.x + associationLocation.x) / 2,
-                  .y = (projectedLocation.y + associationLocation.y) / 2 - textSize.y / 2.0f,
-                  .width = textSize.x,
+               Rectangle roleArea {
+                  .x = (rolePointOccurrence.value().x + rolePointAssociation.value().x) / 2,
+                  .y = (rolePointOccurrence.value().y + rolePointAssociation.value().y) / 2 - roleTextSize.y / 2.0f,
+                  .width = roleTextSize.x,
                   .height = plateHeight,
                };
 
-               renderer.renderText(area, roleStyle.without(Style::ColorType::Line), roleTitle, font, fontSize, spacing);
+               renderer.renderText(roleArea, roleStyle.without(Style::ColorType::Line), roleTitle, font, roleFontSize, spacing);
             }
          }
-
-         Font font = GetFontDefault();
-         float fontSize = 16.0f;
-         float spacing = 1.0f;
-         auto textSize = MeasureTextEx(font, nameText.c_str(), fontSize, spacing);
-
-         float lineThickness = 2.0f;
-
-         Rectangle textArea {
-            .x = projectedLocation.x - textSize.x / 2.0f,
-            .y = projectedLocation.y - textSize.y / 2.0f,
-            .width = textSize.x,
-            .height = textSize.y,
-         };
-         float platePadding = 2.0f;
-         Rectangle plate {
-            .x = textArea.x - platePadding,
-            .y = textArea.y - platePadding,
-            .width = textArea.width + platePadding * 2.0f,
-            .height = textArea.height + platePadding * 2.0f,
-         };
-         float reifierPadding = 2.0f;
-         float reifierOffset = lineThickness + reifierPadding;
-         Rectangle area {
-            .x = plate.x - reifierOffset - lineThickness,
-            .y = plate.y - lineThickness,
-            .width = plate.width + (reifierOffset * 2.0f) + (lineThickness * 2.0f),
-            .height = plate.height + (lineThickness * 2.0f),
-         };
 
          auto occurrenceStyle
             = Styles::resolve(occurrence.getAppearance(), occurrence.getType(), view.ofViewScope(), view.ofMap()).withDefaultsFrom(defaultStyle);
@@ -500,8 +515,10 @@ void MainWindow::renderMap(MapRenderer &renderer, contomap::editor::Selection co
             occurrenceStyle = highlightedStyle(occurrenceStyle);
          }
 
-         renderer.renderOccurrencePlate(occurrence.getId(), area, occurrenceStyle, plate, lineThickness, occurrence.hasReifier());
-         renderer.renderText(textArea, Style().with(Style::ColorType::Text, occurrenceStyle.get(Style::ColorType::Text)), nameText, font, fontSize, spacing);
+         renderer.renderOccurrencePlate(
+            occurrence.getId(), occurrenceArea, occurrenceStyle, occurrencePlate, occurrenceBorderThickness, occurrence.hasReifier());
+         renderer.renderText(
+            occurrenceTextArea, Style().with(Style::ColorType::Text, occurrenceStyle.get(Style::ColorType::Text)), nameText, font, occurrenceFontSize, spacing);
       }
    }
 }

--- a/frontend/src/cpp/MainWindow.cpp
+++ b/frontend/src/cpp/MainWindow.cpp
@@ -317,9 +317,10 @@ void MainWindow::drawMap(Vector2 focusCoordinate)
 {
    DirectMapRenderer directMapRenderer;
    FocusInterceptor focusInterceptor(directMapRenderer, focusCoordinate);
-
-   renderMap(focusInterceptor, view.ofSelection(), currentFocus, selectionDrawOffset);
-
+   MapRenderList renderList;
+   renderMap(renderList, view.ofSelection(), currentFocus, selectionDrawOffset);
+   renderList.optimize();
+   renderList.renderTo(focusInterceptor);
    currentFocus = focusInterceptor.getNewFocus();
 }
 
@@ -922,6 +923,7 @@ void MainWindow::save()
 {
    contomap::frontend::MapRenderList renderList;
    renderMap(renderList, {}, {}, SpacialCoordinate::Offset::of(0.0f, 0.0f));
+   renderList.optimize();
    contomap::frontend::MapRenderMeasurer measurer;
    renderList.renderTo(measurer);
    auto mapArea = measurer.getArea();

--- a/frontend/src/cpp/MapRenderList.cpp
+++ b/frontend/src/cpp/MapRenderList.cpp
@@ -6,30 +6,64 @@ using contomap::frontend::MapRenderList;
 using contomap::model::Identifier;
 using contomap::model::Style;
 
+void MapRenderList::optimize()
+{
+   flushPendingCommand();
+   commands.sort([](auto const &a, auto const &b) { return a->getSortLayer() < b->getSortLayer(); });
+}
+
 void MapRenderList::renderTo(contomap::frontend::MapRenderer &renderer) const
 {
    for (auto const &command : commands)
    {
       command->renderTo(renderer);
    }
+   if (pendingCommand != nullptr)
+   {
+      pendingCommand->renderTo(renderer);
+   }
 }
 
 void MapRenderList::renderText(Rectangle area, Style const &style, std::string const &text, Font font, float fontSize, float spacing)
 {
-   commands.emplace_back(std::make_unique<TextRenderCommand>(area, style, text, font, fontSize, spacing));
+   addToLastCommand(std::make_unique<TextRenderCommand>(area, style, text, font, fontSize, spacing));
 }
 
 void MapRenderList::renderOccurrencePlate(Identifier id, Rectangle area, Style const &style, Rectangle plate, float lineThickness, bool reified)
 {
-   commands.emplace_back(std::make_unique<OccurrenceRenderCommand>(id, area, style, plate, lineThickness, reified));
+   startNewCommand(std::make_unique<OccurrenceRenderCommand>(id, area, style, plate, lineThickness, reified));
 }
 
 void MapRenderList::renderAssociationPlate(Identifier id, Rectangle area, Style const &style, Rectangle plate, float lineThickness, bool reified)
 {
-   commands.emplace_back(std::make_unique<AssociationRenderCommand>(id, area, style, plate, lineThickness, reified));
+   startNewCommand(std::make_unique<AssociationRenderCommand>(id, area, style, plate, lineThickness, reified));
 }
 
 void MapRenderList::renderRoleLine(Identifier id, Vector2 a, Vector2 b, Style const &style, float lineThickness, bool reified)
 {
-   commands.emplace_back(std::make_unique<RoleRenderCommand>(id, a, b, style, lineThickness, reified));
+   startNewCommand(std::make_unique<RoleRenderCommand>(id, a, b, style, lineThickness, reified));
+}
+
+void MapRenderList::startNewCommand(std::unique_ptr<TypedRenderCommand> command)
+{
+   flushPendingCommand();
+   pendingCommand = std::move(command);
+}
+
+void MapRenderList::addToLastCommand(std::unique_ptr<RenderCommand> command)
+{
+   if (pendingCommand == nullptr) [[unlikely]]
+   {
+      commands.emplace_back(std::make_unique<UnknownRenderCommand>(std::move(command)));
+      return;
+   }
+   pendingCommand->addAuxiliary(std::move(command));
+}
+
+void MapRenderList::flushPendingCommand()
+{
+   if (pendingCommand != nullptr) [[likely]]
+   {
+      commands.emplace_back(std::move(pendingCommand));
+   }
 }

--- a/frontend/src/h/contomap/frontend/DirectMapRenderer.h
+++ b/frontend/src/h/contomap/frontend/DirectMapRenderer.h
@@ -21,6 +21,9 @@ public:
    void renderAssociationPlate(
       contomap::model::Identifier id, Rectangle area, contomap::model::Style const &style, Rectangle plate, float lineThickness, bool reified) override;
    void renderRoleLine(contomap::model::Identifier id, Vector2 a, Vector2 b, contomap::model::Style const &style, float lineThickness, bool reified) override;
+
+private:
+   static void drawLine(Vector2 a, Color colorA, Vector2 b, Color colorB, float thickness);
 };
 
 } // namespace contomap::frontend

--- a/frontend/src/h/contomap/frontend/FocusInterceptor.h
+++ b/frontend/src/h/contomap/frontend/FocusInterceptor.h
@@ -34,8 +34,6 @@ public:
    void renderRoleLine(contomap::model::Identifier id, Vector2 a, Vector2 b, contomap::model::Style const &style, float lineThickness, bool reified) override;
 
 private:
-   [[nodiscard]] static Vector2 centerOf(Rectangle area);
-
    contomap::frontend::MapRenderer &next;
    Vector2 focusCoordinate;
    Focus newFocus;

--- a/frontend/src/h/contomap/frontend/Geometry.h
+++ b/frontend/src/h/contomap/frontend/Geometry.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <optional>
+#include <tuple>
+
+#include <raylib.h>
+
+namespace contomap::frontend::geometry
+{
+
+/**
+ * Calculate the point at which two lines intersect.
+ *
+ * @param a the start/end points of line A.
+ * @param b the start/end points of line B.
+ * @return the coordinate at which the two lines intersect, if they do.
+ */
+[[nodiscard]] std::optional<Vector2> intersectLines(std::tuple<Vector2, Vector2> a, std::tuple<Vector2, Vector2> b);
+
+/**
+ * Calculate the point at which a line intersects the border of a box.
+ * One point of the line is at the center of a box.
+ *
+ * @param start the other point of the line.
+ * @param box the box to intersect.
+ * @return the point of the intersection, if the other point is outside the box.
+ */
+[[nodiscard]] std::optional<Vector2> intersectLineIntoBoxCenter(Vector2 start, Rectangle box);
+
+/**
+ * Calculate the center point of a rectangular area.
+ *
+ * @param area the area to consider.
+ * @return the center point in that area.
+ */
+[[nodiscard]] Vector2 centerOf(Rectangle area);
+
+}

--- a/frontend/src/h/contomap/frontend/MapRenderList.h
+++ b/frontend/src/h/contomap/frontend/MapRenderList.h
@@ -18,6 +18,11 @@ public:
    ~MapRenderList() override = default;
 
    /**
+    * Optimizes the list for better display.
+    */
+   void optimize();
+
+   /**
     * Requests to render the list to the given renderer.
     *
     * @param renderer the renderer to call
@@ -38,6 +43,26 @@ private:
       virtual ~RenderCommand() = default;
 
       virtual void renderTo(contomap::frontend::MapRenderer &renderer) const = 0;
+   };
+
+   class RenderCommandStack : public RenderCommand
+   {
+   public:
+      void add(std::unique_ptr<RenderCommand> command)
+      {
+         commands.emplace_back(std::move(command));
+      }
+
+      void renderTo(contomap::frontend::MapRenderer &renderer) const override
+      {
+         for (auto const &command : commands)
+         {
+            command->renderTo(renderer);
+         }
+      }
+
+   private:
+      std::list<std::unique_ptr<RenderCommand>> commands;
    };
 
    class TextRenderCommand : public RenderCommand
@@ -67,7 +92,67 @@ private:
       float spacing;
    };
 
-   class OccurrenceRenderCommand : public RenderCommand
+   class TypedRenderCommand : public RenderCommand
+   {
+   public:
+      enum class SortLayer
+      {
+         Roles = 0,
+         Associations = 1,
+         Occurrences = 2,
+         Unknown = 3,
+      };
+
+      void renderTo(contomap::frontend::MapRenderer &renderer) const override
+      {
+         renderBaseTo(renderer);
+         if (auxiliaryCommands != nullptr)
+         {
+            auxiliaryCommands->renderTo(renderer);
+         }
+      }
+
+      void addAuxiliary(std::unique_ptr<RenderCommand> command)
+      {
+         if (auxiliaryCommands == nullptr)
+         {
+            auxiliaryCommands = std::make_unique<RenderCommandStack>();
+         }
+         auxiliaryCommands->add(std::move(command));
+      }
+
+      [[nodiscard]] virtual SortLayer getSortLayer() const = 0;
+
+   protected:
+      virtual void renderBaseTo(contomap::frontend::MapRenderer &renderer) const = 0;
+
+   private:
+      std::unique_ptr<RenderCommandStack> auxiliaryCommands;
+   };
+
+   class UnknownRenderCommand : public TypedRenderCommand
+   {
+   public:
+      explicit UnknownRenderCommand(std::unique_ptr<RenderCommand> nested)
+         : nested(std::move(nested))
+      {
+      }
+
+      [[nodiscard]] SortLayer getSortLayer() const override
+      {
+         return SortLayer::Unknown;
+      }
+
+      void renderBaseTo(contomap::frontend::MapRenderer &renderer) const override
+      {
+         nested->renderTo(renderer);
+      }
+
+   private:
+      std::unique_ptr<RenderCommand> nested;
+   };
+
+   class OccurrenceRenderCommand : public TypedRenderCommand
    {
    public:
       OccurrenceRenderCommand(contomap::model::Identifier id, Rectangle area, contomap::model::Style style, Rectangle plate, float lineThickness, bool reified)
@@ -80,7 +165,12 @@ private:
       {
       }
 
-      void renderTo(contomap::frontend::MapRenderer &renderer) const override
+      [[nodiscard]] SortLayer getSortLayer() const override
+      {
+         return SortLayer::Occurrences;
+      }
+
+      void renderBaseTo(contomap::frontend::MapRenderer &renderer) const override
       {
          renderer.renderOccurrencePlate(id, area, style, plate, lineThickness, reified);
       }
@@ -94,7 +184,7 @@ private:
       bool reified;
    };
 
-   class AssociationRenderCommand : public RenderCommand
+   class AssociationRenderCommand : public TypedRenderCommand
    {
    public:
       AssociationRenderCommand(contomap::model::Identifier id, Rectangle area, contomap::model::Style style, Rectangle plate, float lineThickness, bool reified)
@@ -107,7 +197,12 @@ private:
       {
       }
 
-      void renderTo(contomap::frontend::MapRenderer &renderer) const override
+      [[nodiscard]] SortLayer getSortLayer() const override
+      {
+         return SortLayer::Associations;
+      }
+
+      void renderBaseTo(contomap::frontend::MapRenderer &renderer) const override
       {
          renderer.renderAssociationPlate(id, area, style, plate, lineThickness, reified);
       }
@@ -121,7 +216,7 @@ private:
       bool reified;
    };
 
-   class RoleRenderCommand : public RenderCommand
+   class RoleRenderCommand : public TypedRenderCommand
    {
    public:
       RoleRenderCommand(contomap::model::Identifier id, Vector2 a, Vector2 b, contomap::model::Style style, float lineThickness, bool reified)
@@ -134,7 +229,12 @@ private:
       {
       }
 
-      void renderTo(contomap::frontend::MapRenderer &renderer) const override
+      [[nodiscard]] SortLayer getSortLayer() const override
+      {
+         return SortLayer::Roles;
+      }
+
+      void renderBaseTo(contomap::frontend::MapRenderer &renderer) const override
       {
          renderer.renderRoleLine(id, a, b, style, lineThickness, reified);
       }
@@ -148,7 +248,12 @@ private:
       bool reified;
    };
 
-   std::list<std::unique_ptr<RenderCommand>> commands;
+   void startNewCommand(std::unique_ptr<TypedRenderCommand> command);
+   void addToLastCommand(std::unique_ptr<RenderCommand> command);
+   void flushPendingCommand();
+
+   std::list<std::unique_ptr<TypedRenderCommand>> commands;
+   std::unique_ptr<TypedRenderCommand> pendingCommand;
 };
 
 } // namespace contomap::frontend

--- a/frontend/test/GeometryTest.cpp
+++ b/frontend/test/GeometryTest.cpp
@@ -1,0 +1,59 @@
+#include <gmock/gmock.h>
+
+#include "contomap/frontend/Geometry.h"
+
+using contomap::frontend::geometry::centerOf;
+using contomap::frontend::geometry::intersectLineIntoBoxCenter;
+using contomap::frontend::geometry::intersectLines;
+
+MATCHER_P(isCloseTo, expected, "")
+{
+   return (std::abs(arg.x - expected.x) < 0.001f) && (std::abs(arg.y - expected.y) < 0.001f);
+}
+
+std::ostream &operator<<(std::ostream &os, Vector2 const &v)
+{
+   return os << ".x=" << v.x << "f, .y=" << v.y << "f";
+}
+
+TEST(GeometryTest, centerOfRectangle)
+{
+   EXPECT_THAT(centerOf(Rectangle { .x = 0.0f, .y = 0.0f, .width = 0.0f, .height = 0.0f }), isCloseTo(Vector2 { .x = 0.0f, .y = 0.0f }));
+   EXPECT_THAT(centerOf(Rectangle { .x = 0.0f, .y = 0.0f, .width = 10.0f, .height = 20.0f }), isCloseTo(Vector2 { .x = 5.0f, .y = 10.0f }));
+   EXPECT_THAT(centerOf(Rectangle { .x = -5.0f, .y = -10.0f, .width = 10.0f, .height = 20.0f }), isCloseTo(Vector2 { .x = 0.0f, .y = 0.0f }));
+}
+
+TEST(GeometryTest, intersectLines)
+{
+   auto line1 = std::make_tuple(Vector2 { .x = 1.0f, .y = 1.0f }, Vector2 { .x = 10.0f, .y = 1.0f });
+   auto line2 = std::make_tuple(Vector2 { .x = 1.0f, .y = 2.0f }, Vector2 { .x = 10.0f, .y = 2.0f });
+   auto line3 = std::make_tuple(Vector2 { .x = 2.0f, .y = 0.5f }, Vector2 { .x = 2.0f, .y = 2.0f });
+   auto zeroX = std::make_tuple(Vector2 { .x = 0.0f, .y = -1.0f }, Vector2 { .x = 0.0f, .y = 1.0f });
+   auto zeroY = std::make_tuple(Vector2 { .x = -1.0f, .y = 0.0f }, Vector2 { .x = 1.0f, .y = 0.0f });
+   auto pointOn1 = std::make_tuple(Vector2 { .x = 3.0f, .y = 1.0f }, Vector2 { .x = 3.0f, .y = 1.0f });
+
+   EXPECT_FALSE(intersectLines(line1, line2).has_value()) << "non-crossing lines";
+   EXPECT_THAT(intersectLines(line1, line3).value(), isCloseTo(Vector2 { .x = 2.0f, .y = 1.0f })) << "crossing lines";
+   EXPECT_THAT(intersectLines(line2, line3).value(), isCloseTo(Vector2 { .x = 2.0f, .y = 2.0f })) << "touching line";
+
+   EXPECT_FALSE(intersectLines(line1, line1).has_value()) << "overlapping line";
+
+   EXPECT_THAT(intersectLines(zeroX, zeroY).value(), isCloseTo(Vector2 { .x = 0.0f, .y = 0.0f })) << "lines with zero component";
+
+   EXPECT_FALSE(intersectLines(line2, pointOn1).has_value()) << "point outside line";
+   EXPECT_FALSE(intersectLines(line1, pointOn1).has_value()) << "point on line"; // accepted limitation of implementation
+}
+
+TEST(GeometryTest, intersectLineIntoBoxCenter)
+{
+   Rectangle box { .x = 1.0f, .y = 1.0f, .width = 1.0f, .height = 1.0f };
+   EXPECT_FALSE(intersectLineIntoBoxCenter(Vector2 { .x = 1.5f, .y = 1.5f }, box).has_value()) << "start equal center";
+   EXPECT_FALSE(intersectLineIntoBoxCenter(Vector2 { .x = 1.25f, .y = 1.25f }, box).has_value()) << "start within box";
+
+   EXPECT_THAT(intersectLineIntoBoxCenter(Vector2 { .x = 0.0f, .y = 1.5f }, box).value(), isCloseTo(Vector2 { .x = 1.0f, .y = 1.5f })) << "at left side";
+   EXPECT_THAT(intersectLineIntoBoxCenter(Vector2 { .x = 1.5f, .y = 0.0f }, box).value(), isCloseTo(Vector2 { .x = 1.5f, .y = 1.0f })) << "at bottom side";
+   EXPECT_THAT(intersectLineIntoBoxCenter(Vector2 { .x = 1.5f, .y = 3.0f }, box).value(), isCloseTo(Vector2 { .x = 1.5f, .y = 2.0f })) << "at top side";
+   EXPECT_THAT(intersectLineIntoBoxCenter(Vector2 { .x = 3.0f, .y = 1.5f }, box).value(), isCloseTo(Vector2 { .x = 2.0f, .y = 1.5f })) << "at right side";
+
+   EXPECT_THAT(intersectLineIntoBoxCenter(Vector2 { .x = 0.0f, .y = 0.0f }, box).value(), isCloseTo(Vector2 { .x = 1.0f, .y = 1.0f })) << "at corner";
+}


### PR DESCRIPTION
This pull request increases the quality of the rendered images:

* order of visible elements is: roles, association, occurrences
* role lines have blended ends towards their targets

Also included: creating an association will have it centred between the _selected_ occurrences, not all of the topic.